### PR TITLE
Add ability to use custom event listener

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@timsexperiments/three-rubiks-cube",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "API for a Three JS Rubik's Cube implemented as an THREE.Object3D.",
   "main": "dist/esm/index.js",
   "exports": {

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -1,2 +1,3 @@
 export { RubiksCube } from './cube';
 export { explodeAndReassemble } from './transform';
+export type { CubeEventHandlersEventMap, CubeEventListener } from './types';

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -1,0 +1,36 @@
+export interface CubeEventHandlersEventMap {
+  keydown: {
+    /** The key that was pressed down. */
+    key: string;
+  };
+  mousedown: {
+    /** The X position that the mouse down event occured at. */
+    clientX: number;
+    /** The Y position that the mouse down event occured at. */
+    clientY: number;
+  };
+  mousemove: {
+    /** The X position that the mouse down event occured at. */
+    clientX: number;
+    /** The Y position that the mouse down event occured at. */
+    clientY: number;
+  };
+  mouseup: undefined;
+}
+
+/**
+ * A custom event listener that dispacthes the correct events for the cube to listen to.
+ *
+ * This allows the cube to use a custom event listener when working in web workers.
+ */
+export interface CubeEventListener {
+  addEventListener<K extends keyof CubeEventHandlersEventMap>(
+    type: K,
+    listener: (this: Window, ev: CubeEventHandlersEventMap[K]) => any,
+  ): void;
+
+  addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+  ): void;
+}


### PR DESCRIPTION
- Adds the ability to use a custom event listener for the actions of the cube. This allows for the cube to be used in scenarios such as web workers. 
- Adds the usage of a `CustomCubeEventListener` to the example project.