### PR TITLE
Add ability to use custom event listener

### DIFF
--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -11,7 +11,7 @@ class CustomCubeEventListener implements CubeEventListener {
     [key in keyof CubeEventHandlersEventMap]?: (
       ev: CubeEventHandlersEventMap[key],
     ) => any;
-  } = {};
+  }[] = [];
 
   constructor() {
     window.addEventListener('keydown', (ev) => {
@@ -33,7 +33,12 @@ class CustomCubeEventListener implements CubeEventListener {
     listener: (ev: CubeEventHandlersEventMap[K]) => any,
   ): void {
     // @ts-ignore
-    this.listeners[type] = listener;
+    if (!this.listeners[type]) {
+      // @ts-ignore
+      this.listeners[type] = [];
+    }
+    // @ts-ignore
+    this.listeners[type].push(listener);
   }
 
   // This method is called by the worker to dispatch events
@@ -41,8 +46,9 @@ class CustomCubeEventListener implements CubeEventListener {
     type: K,
     ev: CubeEventHandlersEventMap[K],
   ) {
-    const listener = this.listeners[type];
-    if (listener) {
+    // @ts-ignore
+    const listeners = this.listeners[type];
+    for (const listener of listeners ?? []) {
       listener(ev);
     }
   }
@@ -126,6 +132,27 @@ canvas.addEventListener('dblclick', () => {
     canvas.requestFullscreen();
   } else {
     document.exitFullscreen();
+  }
+});
+
+window.addEventListener('keydown', (ev) => {
+  switch (ev.key) {
+    case 'h':
+    case 'H':
+      cube.shuffle(10, { duration: 200 });
+      break;
+    case 'r':
+    case 'e':
+      explodeAndReassemble(cube, { range: 15 });
+      break;
+    case 'x':
+    case 'X':
+      cube.disableInteraction();
+      break;
+    case 'c':
+    case 'C':
+      cube.enableInteraction();
+      break;
   }
 });
 

--- a/lib/src/transform.ts
+++ b/lib/src/transform.ts
@@ -35,6 +35,93 @@ type ExplodeOptions = {
  * @param cube - The {@link RubiksCube} instance to be exploded and reassembled.
  * @param options - Optional configuration for the explosion and reassembly.
  *
+<<<<<<< HEAD
+=======
+ * @example
+ * // Example usage
+ * explodeAndReassemble(rubiksCube, {
+ *   duration: 1500,
+ *   range: 15,
+ *   reassembleDelay: 700,
+ *   callback: () => {
+ *     console.log('Cube has been reassembled');
+ *   },
+ * });
+ */
+export function explodeAndReassemble(
+  cube: RubiksCube,
+  options?: ExplodeOptions,
+) {
+  cube.runTransformation(() => {
+    cube.disableInteraction();
+    const clock = new THREE.Clock();
+    const {
+      duration = 1000,
+      range = 10,
+      reassembleDelay = 500,
+      onComplete,
+    } = options ?? {};
+    const originalPositions: THREE.Vector3[] = [];
+    cube.children.forEach((child) => {
+      originalPositions.push(child.position.clone());
+    });
+
+    const randomPositions = generateRandomPositions(cube, { range });
+
+    const animate = async (startTime: number, explode: boolean) => {
+      const elapsedTime = clock.getElapsedTime() - startTime;
+      const progress = Math.min((elapsedTime / duration) * 1000, 1);
+      const easedProgress = easeInOutCubic(progress);
+
+      cube.children.forEach((child, index) => {
+        if (explode) {
+          child.position.lerpVectors(
+            originalPositions[index],
+            randomPositions[index],
+            easedProgress,
+          );
+        } else {
+          child.position.lerpVectors(
+            randomPositions[index],
+            originalPositions[index],
+            easedProgress,
+          );
+        }
+      });
+
+      if (progress < 1) {
+        requestAnimationFrame(() => animate(startTime, explode));
+      } else if (explode) {
+        setTimeout(() => {
+          requestAnimationFrame(() => animate(clock.getElapsedTime(), false));
+        }, reassembleDelay);
+      } else {
+        onComplete && onComplete();
+        cube.enableInteraction();
+      }
+    };
+
+    const perfStartTime = performance.now();
+    requestAnimationFrame(() => animate(clock.getElapsedTime(), true));
+  });
+}
+
+/**
+ * Asynchronously animates the explosion and reassembly of the given
+ * {@link RubiksCube}.
+ *
+ * This function creates a visual effect where the Rubik's Cube pieces explode
+ * outward to random positions and then reassemble back to their original
+ * positions. The animation uses an ease-in-out cubic easing function for smooth
+ * transitions.
+ *
+ * This asynchronous version returns a promise that resolves upon completion of
+ * the reassembly.
+ *
+ * @param cube - The {@link RubiksCube} instance to be exploded and reassembled.
+ * @param options - Optional configuration for the explosion and reassembly.
+ *
+>>>>>>> bab2440 (Add ability to disable and enable user interactions with the cube.)
  * @returns A promise that resolves when the reassembly is complete.
  *
  * @example
@@ -52,10 +139,16 @@ export function explodeAndReassemble(
 ) {
   const { onComplete, ...rest } = options ?? {};
   return new Promise<void>(async (res) => {
+<<<<<<< HEAD
     explodeAndReassembleInternal(cube, {
+=======
+    cube.disableInteraction();
+    explodeAndReassemble(cube, {
+>>>>>>> bab2440 (Add ability to disable and enable user interactions with the cube.)
       ...rest,
       onComplete: async () => {
         onComplete && (await onComplete());
+        cube.enableInteraction();
         res();
       },
     });


### PR DESCRIPTION
### TL;DR

Extended `CustomCubeEventListener` to support multiple listeners per event type and added interaction enable/disable functionality to `RubiksCube`.

### What changed?

- Changed the `listeners` property in `CustomCubeEventListener` from an object to an array of objects.
- Updated `CustomCubeEventListener.addListener` to push listeners to an array, allowing multiple listeners per event type.
- Modified `dispatchEvent` to iterate over all listeners for a given event type.
- Bound new keyboard event handlers in `main.ts` for shuffling, exploding, disabling, and enabling interaction with the cube.
- Added `interactionEnabled` property to `RubiksCube` to control whether interactions are allowed.
- Updated mouse and keyboard event handlers in `RubiksCube` to respect `interactionEnabled`.
- Modified transformation methods to disable interactions during transformations and re-enable them afterward.

### How to test?

1. Run the application.
2. Attempt to add multiple event listeners to a single event type in `CustomCubeEventListener` and ensure all are called.
3. Trigger cube transformations and ensure that interactions are disabled during transformations and re-enabled afterward.
4. Use the new keyboard shortcuts to shuffle, explode, disable, and enable interaction.

### Why make this change?

This change increases the flexibility and robustness of the event listener system and improves user interaction handling during cube transformations.

---

