### PR TITLE
Add controls enable/disable functionality to RubiksCube class

### DIFF
--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -87,6 +87,12 @@ cube.shuffle(10, {
     await explodeAndReassemble(cube, { range: 15 });
     explodeAndReassemble(cube, { range: 15 }).then(() => {
       cube.rotateSlice('x', 0, 'clockwise', { duration: 300 });
+      cube.disableControls();
+      console.log('Controls disabled');
+      setTimeout(() => {
+        cube.enableControls();
+        console.log('Controls enabled');
+      }, 5000);
     });
   },
 });

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@timsexperiments/three-rubiks-cube",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "API for a Three JS Rubik's Cube implemented as an THREE.Object3D.",
   "main": "dist/esm/index.js",
   "exports": {

--- a/lib/src/cube.ts
+++ b/lib/src/cube.ts
@@ -72,6 +72,7 @@ export class RubiksCube extends THREE.Object3D {
   private rotationSection: 0 | 1 | 2 | null = null;
   private rotationAngle: number | null = null;
   private isTranforming: boolean = false;
+  private controlsEnabled: boolean = true;
 
   /**
    * Creates a new `RubiksCube` instance.
@@ -206,6 +207,7 @@ export class RubiksCube extends THREE.Object3D {
   }
 
   private onMouseDown(event: { clientX: number; clientY: number }) {
+    if (!this.controlsEnabled) return;
     if (this.initialIntersect || this.isTranforming) return;
     const canvasBounds = this.canvas.getBoundingClientRect();
     this.mouse.x =
@@ -225,6 +227,7 @@ export class RubiksCube extends THREE.Object3D {
   }
 
   private onMouseMove(event: { clientX: number; clientY: number }) {
+    if (!this.controlsEnabled) return;
     if (!this.isDragging || !this.initialIntersect) return;
 
     const { x: startX, y: startY } = this.dragStart;
@@ -289,6 +292,7 @@ export class RubiksCube extends THREE.Object3D {
   }
 
   private onKeyboardRotation(event: { key: string }) {
+    if (!this.controlsEnabled) return;
     switch (event.key) {
       case 'ArrowUp':
       case 'w':
@@ -796,6 +800,16 @@ export class RubiksCube extends THREE.Object3D {
       await transformation();
       this.isTranforming = false;
     });
+  }
+
+  /** Enables event controls. */
+  public enableControls() {
+    this.controlsEnabled = true;
+  }
+
+  /** Disables event controls. */
+  public disableControls() {
+    this.controlsEnabled = false;
   }
 }
 


### PR DESCRIPTION
The pull request introduces a new feature to the RubiksCube class that allows controls to be enabled or disabled. This is controlled via the `enableControls` and `disableControls` methods and prevents interactions such as mouse and keyboard events when controls are disabled. Additionally, controls are temporarily disabled during the explodeAndReassemble animation in the main script. The package version is also incremented from 0.1.1 to 0.1.2.

---

